### PR TITLE
Include Liam's fixes as well as fix MacOS build

### DIFF
--- a/lib/libstem/files.xml
+++ b/lib/libstem/files.xml
@@ -2,7 +2,9 @@
 	<files id="native-libstem">
 		
 		<file name="${LINC_STEMPAD_PATH}lib/libstem/src/Gamepad_private.c"/>
-		<file name="${LINC_STEMPAD_PATH}lib/libstem/src/Gamepad_windows_dinput.c"/>
+		<file name="${LINC_STEMPAD_PATH}lib/libstem/src/Gamepad_windows_dinput.c" if="windows" />
+    <file name="${LINC_STEMPAD_PATH}lib/libstem/src/Gamepad_macosx.c" if="mac" />
+    <file name="${LINC_STEMPAD_PATH}lib/libstem/src/Gamepad_linux.c" if="linux" />
 		
 	</files>
 	

--- a/lib/libstem/files.xml
+++ b/lib/libstem/files.xml
@@ -10,7 +10,7 @@
 	
 	<target id="haxe">
 		<!-- add linker flags to the haxe build output -->
-
+        <vflag name="-framework" value="IOKit" if="mac" />
         <!-- reference the files in the haxe target so they get included -->
         <files id="native-libstem"/>
 	</target>

--- a/lib/libstem/src/Gamepad.h
+++ b/lib/libstem/src/Gamepad.h
@@ -26,13 +26,7 @@
 extern "C" {
 #endif
 
-#if _MSC_VER <= 1600
-#define bool int
-#define true 1
-#define false 0
-#else
 #include <stdbool.h>
-#endif
 
 struct Gamepad_device {
 	// Unique device identifier for application session, starting at 0 for the first device attached and

--- a/lib/libstem/src/Gamepad_linux.c
+++ b/lib/libstem/src/Gamepad_linux.c
@@ -20,8 +20,8 @@
   Alex Diener alex@ludobloom.com
 */
 
-#include "gamepad/Gamepad.h"
-#include "gamepad/Gamepad_private.h"
+#include "Gamepad.h"
+#include "Gamepad_private.h"
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>

--- a/lib/libstem/src/Gamepad_macosx.c
+++ b/lib/libstem/src/Gamepad_macosx.c
@@ -20,8 +20,8 @@
   Alex Diener alex@ludobloom.com
 */
 
-#include "gamepad/Gamepad.h"
-#include "gamepad/Gamepad_private.h"
+#include "Gamepad.h"
+#include "Gamepad_private.h"
 #include <IOKit/hid/IOHIDLib.h>
 #include <limits.h>
 #include <mach/mach.h>

--- a/linc/linc_stempad.xml
+++ b/linc/linc_stempad.xml
@@ -9,7 +9,6 @@
         <!-- add files and flags to the haxe c++ build -->
 
         <compilerflag value='-I${LINC_STEMPAD_PATH}/linc/'/>
-        <compilerflag value='-DSTEMPAD_EXAMPLE_DEFINE_FOR_THE_CPP_CODE'/>
 
         <file name='${LINC_STEMPAD_PATH}linc/linc_stempad.cpp' />
 


### PR DESCRIPTION
After adding liam's fixes that removed dependencies on MSVC I ran into some nasty linker errors everywhere.

Turns out it was because all of IOKit was missing, which was easy enough to fix.